### PR TITLE
feat: more secure default for sqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0]() (2025-12-29)
+
+### Breaking changes
+* Update the default `principal_roles`, remove the wide access `*`
+
+### Features
+
+* Update module source to Terraform Registry format (c0x12c/sqs/aws)
+* Add `enabled_dlq_queue_policy` variable to optionally enable dead letter queue policy
+* Add separate IAM policy document and queue policy resources for DLQ
+
 ## [0.2.4]() (2025-07-07)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ module "sqs" {
 - [Example](./examples/complete/)
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
-| Name                                                                     | Version  |
-| ------------------------------------------------------------------------ | -------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9.8 |
-| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 5.75  |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75 |
 
 ## Providers
 
-| Name                                             | Version |
-| ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.75 |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75 |
 
 ## Modules
 
@@ -47,53 +47,57 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                      | Type        |
-| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_iam_policy.read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                             | resource    |
-| [aws_iam_policy.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                       | resource    |
-| [aws_iam_policy.write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                            | resource    |
-| [aws_sqs_queue.dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue)                                | resource    |
-| [aws_sqs_queue.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue)                              | resource    |
-| [aws_sqs_queue_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy)                 | resource    |
-| [aws_sqs_queue_redrive_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_redrive_policy) | resource    |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity)             | data source |
-| [aws_iam_policy_document.read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)        | data source |
-| [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)  | data source |
-| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)        | data source |
-| [aws_iam_policy_document.write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document)       | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region)                               | data source |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_sqs_queue.dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_sqs_queue.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
+| [aws_sqs_queue_policy.dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
+| [aws_sqs_queue_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
+| [aws_sqs_queue_redrive_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_redrive_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sqs_dlq](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
-| Name                                                                                                                 | Description                                                                                                                        | Type           | Default    | Required |
-| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- | :------: |
-| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input_content_based_deduplication) | Max receive message count                                                                                                          | `bool`         | `false`    |    no    |
-| <a name="input_delay_seconds"></a> [delay\_seconds](#input_delay_seconds)                                            | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900                       | `string`       | `"0"`      |    no    |
-| <a name="input_dlq_retention_seconds"></a> [dlq\_retention\_seconds](#input_dlq_retention_seconds)                   | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days)          | `string`       | `"259200"` |    no    |
-| <a name="input_enabled_dead_letter_queue"></a> [enabled\_dead\_letter\_queue](#input_enabled_dead_letter_queue)      | Enable dead letter queue                                                                                                           | `bool`         | `true`     |    no    |
-| <a name="input_enabled_read_write_policy"></a> [enabled\_read\_write\_policy](#input_enabled_read_write_policy)      | Enable read-write policy                                                                                                           | `bool`         | `false`    |    no    |
-| <a name="input_fifo_deduplication_scope"></a> [fifo\_deduplication\_scope](#input_fifo_deduplication_scope)          | Specifies whether message deduplication occurs at the message group or queue level. (perQueue or perMessageGroupId)                | `string`       | `null`     |    no    |
-| <a name="input_fifo_enabled"></a> [fifo\_enabled](#input_fifo_enabled)                                               | Specify whether enable FIFO or not for the SQS queue                                                                               | `bool`         | `false`    |    no    |
-| <a name="input_fifo_throughput_limit"></a> [fifo\_throughput\_limit](#input_fifo_throughput_limit)                   | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group (perQueue or perMessageGroupId) | `string`       | `null`     |    no    |
-| <a name="input_max_receive_count"></a> [max\_receive\_count](#input_max_receive_count)                               | Max receive message count                                                                                                          | `number`       | `3`        |    no    |
-| <a name="input_max_size"></a> [max\_size](#input_max_size)                                                           | The limit of how many bytes a message can contain before Amazon SQS rejects it                                                     | `string`       | `"2048"`   |    no    |
-| <a name="input_name"></a> [name](#input_name)                                                                        | The name for creating queue names                                                                                                  | `string`       | n/a        |   yes    |
-| <a name="input_principal_roles"></a> [principal\_roles](#input_principal_roles)                                      | A list of IAM roles that a specific principal (user, service, or account) can assume.                                              | `list(string)` | `null`     |    no    |
-| <a name="input_read_policy_name"></a> [read\_policy\_name](#input_read_policy_name)                                  | The name of the custom read policy                                                                                                 | `string`       | `null`     |    no    |
-| <a name="input_read_write_policy_name"></a> [read\_write\_policy\_name](#input_read_write_policy_name)               | Custom name for the read-write policy                                                                                              | `string`       | `null`     |    no    |
-| <a name="input_retention_seconds"></a> [retention\_seconds](#input_retention_seconds)                                | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days)          | `string`       | `"86400"`  |    no    |
-| <a name="input_visibility_timeout_seconds"></a> [visibility\_timeout\_seconds](#input_visibility_timeout_seconds)    | The visibility timeout for the queue. An integer from 0 to 43200                                                                   | `string`       | `"30"`     |    no    |
-| <a name="input_wait_seconds"></a> [wait\_seconds](#input_wait_seconds)                                               | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning                         | `string`       | `"10"`     |    no    |
-| <a name="input_write_policy_name"></a> [write\_policy\_name](#input_write_policy_name)                               | The name of the custom write policy                                                                                                | `string`       | `null`     |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Max receive message count | `bool` | `false` | no |
+| <a name="input_delay_seconds"></a> [delay\_seconds](#input\_delay\_seconds) | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 | `string` | `"0"` | no |
+| <a name="input_dlq_retention_seconds"></a> [dlq\_retention\_seconds](#input\_dlq\_retention\_seconds) | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days) | `string` | `"259200"` | no |
+| <a name="input_enabled_dead_letter_queue"></a> [enabled\_dead\_letter\_queue](#input\_enabled\_dead\_letter\_queue) | Enable dead letter queue | `bool` | `true` | no |
+| <a name="input_enabled_dlq_queue_policy"></a> [enabled\_dlq\_queue\_policy](#input\_enabled\_dlq\_queue\_policy) | Enable dead letter queue policy | `bool` | `false` | no |
+| <a name="input_enabled_kms_encryption"></a> [enabled\_kms\_encryption](#input\_enabled\_kms\_encryption) | Enable KMS encryption for the SQS queue (by default, AWS SSE-SQS is used) | `bool` | `false` | no |
+| <a name="input_enabled_read_write_policy"></a> [enabled\_read\_write\_policy](#input\_enabled\_read\_write\_policy) | Enable read-write policy | `bool` | `false` | no |
+| <a name="input_fifo_deduplication_scope"></a> [fifo\_deduplication\_scope](#input\_fifo\_deduplication\_scope) | Specifies whether message deduplication occurs at the message group or queue level. (perQueue or perMessageGroupId) | `string` | `null` | no |
+| <a name="input_fifo_enabled"></a> [fifo\_enabled](#input\_fifo\_enabled) | Specify whether enable FIFO or not for the SQS queue | `bool` | `false` | no |
+| <a name="input_fifo_throughput_limit"></a> [fifo\_throughput\_limit](#input\_fifo\_throughput\_limit) | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group (perQueue or perMessageGroupId) | `string` | `null` | no |
+| <a name="input_kms_config"></a> [kms\_config](#input\_kms\_config) | KMS configuration for the SQS queue | <pre>object({<br/>    kms_master_key_id                 = string<br/>    kms_data_key_reuse_period_seconds = number<br/>  })</pre> | <pre>{<br/>  "kms_data_key_reuse_period_seconds": 300,<br/>  "kms_master_key_id": "alias/aws/sqs"<br/>}</pre> | no |
+| <a name="input_max_receive_count"></a> [max\_receive\_count](#input\_max\_receive\_count) | Max receive message count | `number` | `3` | no |
+| <a name="input_max_size"></a> [max\_size](#input\_max\_size) | The limit of how many bytes a message can contain before Amazon SQS rejects it | `string` | `"2048"` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name for creating queue names | `string` | n/a | yes |
+| <a name="input_principal_roles"></a> [principal\_roles](#input\_principal\_roles) | A list of IAM roles that a specific principal (user, service, or account) can assume. | `list(string)` | `null` | no |
+| <a name="input_read_policy_name"></a> [read\_policy\_name](#input\_read\_policy\_name) | The name of the custom read policy | `string` | `null` | no |
+| <a name="input_read_write_policy_name"></a> [read\_write\_policy\_name](#input\_read\_write\_policy\_name) | Custom name for the read-write policy | `string` | `null` | no |
+| <a name="input_retention_seconds"></a> [retention\_seconds](#input\_retention\_seconds) | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days) | `string` | `"86400"` | no |
+| <a name="input_visibility_timeout_seconds"></a> [visibility\_timeout\_seconds](#input\_visibility\_timeout\_seconds) | The visibility timeout for the queue. An integer from 0 to 43200 | `string` | `"30"` | no |
+| <a name="input_wait_seconds"></a> [wait\_seconds](#input\_wait\_seconds) | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning | `string` | `"10"` | no |
+| <a name="input_write_policy_name"></a> [write\_policy\_name](#input\_write\_policy\_name) | The name of the custom write policy | `string` | `null` | no |
 
 ## Outputs
 
-| Name                                                                                                                            | Description                                                      |
-| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| <a name="output_dlq"></a> [dlq](#output_dlq)                                                                                    | The SQS dead letter queue info                                   |
-| <a name="output_iam_policy_sqs_read_arn"></a> [iam\_policy\_sqs\_read\_arn](#output_iam_policy_sqs_read_arn)                    | n/a                                                              |
-| <a name="output_iam_policy_sqs_read_write_arn"></a> [iam\_policy\_sqs\_read\_write\_arn](#output_iam_policy_sqs_read_write_arn) | The ARN of the IAM policy for read-write access to the SQS queue |
-| <a name="output_iam_policy_sqs_write_arn"></a> [iam\_policy\_sqs\_write\_arn](#output_iam_policy_sqs_write_arn)                 | n/a                                                              |
-| <a name="output_queue"></a> [queue](#output_queue)                                                                              | The SQS queue info                                               |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_dlq"></a> [dlq](#output\_dlq) | The SQS dead letter queue info |
+| <a name="output_iam_policy_sqs_read_arn"></a> [iam\_policy\_sqs\_read\_arn](#output\_iam\_policy\_sqs\_read\_arn) | n/a |
+| <a name="output_iam_policy_sqs_read_write_arn"></a> [iam\_policy\_sqs\_read\_write\_arn](#output\_iam\_policy\_sqs\_read\_write\_arn) | The ARN of the IAM policy for read-write access to the SQS queue |
+| <a name="output_iam_policy_sqs_write_arn"></a> [iam\_policy\_sqs\_write\_arn](#output\_iam\_policy\_sqs\_write\_arn) | n/a |
+| <a name="output_queue"></a> [queue](#output\_queue) | The SQS queue info |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ This module will create the following components:
 
 ```hcl
 module "sqs" {
-  source = "github.com/spartan-stratos/terraform-modules//aws/sqs?ref=v0.2.3"
+  source  = "c0x12c/sqs/aws"
+  version = "0.3.0"
 
   name              = "example-queue"
   max_receive_count = 1
-  principal_roles = ["arn:aws:iam::<account-id>:role/sqs-role"]
+  principal_roles   = ["arn:aws:iam::<account-id>:role/sqs-role"]
 }
 ```
 
@@ -29,16 +30,16 @@ module "sqs" {
 
 ## Requirements
 
-| Name                                                                      | Version  |
-|---------------------------------------------------------------------------|----------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.75  |
+| Name                                                                     | Version  |
+| ------------------------------------------------------------------------ | -------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement_terraform) | >= 1.9.8 |
+| <a name="requirement_aws"></a> [aws](#requirement_aws)                   | >= 5.75  |
 
 ## Providers
 
-| Name                                              | Version |
-|---------------------------------------------------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75 |
+| Name                                             | Version |
+| ------------------------------------------------ | ------- |
+| <a name="provider_aws"></a> [aws](#provider_aws) | >= 5.75 |
 
 ## Modules
 
@@ -47,7 +48,7 @@ No modules.
 ## Resources
 
 | Name                                                                                                                                      | Type        |
-|-------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [aws_iam_policy.read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                             | resource    |
 | [aws_iam_policy.read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                       | resource    |
 | [aws_iam_policy.write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                            | resource    |
@@ -64,35 +65,35 @@ No modules.
 
 ## Inputs
 
-| Name                                                                                                                    | Description                                                                                                                        | Type           | Default    | Required |
-|-------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|----------------|------------|:--------:|
-| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Max receive message count                                                                                                          | `bool`         | `false`    |    no    |
-| <a name="input_delay_seconds"></a> [delay\_seconds](#input\_delay\_seconds)                                             | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900                       | `string`       | `"0"`      |    no    |
-| <a name="input_dlq_retention_seconds"></a> [dlq\_retention\_seconds](#input\_dlq\_retention\_seconds)                   | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days)          | `string`       | `"259200"` |    no    |
-| <a name="input_enabled_dead_letter_queue"></a> [enabled\_dead\_letter\_queue](#input\_enabled\_dead\_letter\_queue)     | Enable dead letter queue                                                                                                           | `bool`         | `true`     |    no    |
-| <a name="input_enabled_read_write_policy"></a> [enabled\_read\_write\_policy](#input\_enabled\_read\_write\_policy)     | Enable read-write policy                                                                                                           | `bool`         | `false`    |    no    |
-| <a name="input_fifo_deduplication_scope"></a> [fifo\_deduplication\_scope](#input\_fifo\_deduplication\_scope)          | Specifies whether message deduplication occurs at the message group or queue level. (perQueue or perMessageGroupId)                | `string`       | `null`     |    no    |
-| <a name="input_fifo_enabled"></a> [fifo\_enabled](#input\_fifo\_enabled)                                                | Specify whether enable FIFO or not for the SQS queue                                                                               | `bool`         | `false`    |    no    |
-| <a name="input_fifo_throughput_limit"></a> [fifo\_throughput\_limit](#input\_fifo\_throughput\_limit)                   | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group (perQueue or perMessageGroupId) | `string`       | `null`     |    no    |
-| <a name="input_max_receive_count"></a> [max\_receive\_count](#input\_max\_receive\_count)                               | Max receive message count                                                                                                          | `number`       | `3`        |    no    |
-| <a name="input_max_size"></a> [max\_size](#input\_max\_size)                                                            | The limit of how many bytes a message can contain before Amazon SQS rejects it                                                     | `string`       | `"2048"`   |    no    |
-| <a name="input_name"></a> [name](#input\_name)                                                                          | The name for creating queue names                                                                                                  | `string`       | n/a        |   yes    |
-| <a name="input_principal_roles"></a> [principal\_roles](#input\_principal\_roles)                                       | A list of IAM roles that a specific principal (user, service, or account) can assume.                                              | `list(string)` | `null`     |    no    |
-| <a name="input_read_policy_name"></a> [read\_policy\_name](#input\_read\_policy\_name)                                  | The name of the custom read policy                                                                                                 | `string`       | `null`     |    no    |
-| <a name="input_read_write_policy_name"></a> [read\_write\_policy\_name](#input\_read\_write\_policy\_name)              | Custom name for the read-write policy                                                                                              | `string`       | `null`     |    no    |
-| <a name="input_retention_seconds"></a> [retention\_seconds](#input\_retention\_seconds)                                 | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days)          | `string`       | `"86400"`  |    no    |
-| <a name="input_visibility_timeout_seconds"></a> [visibility\_timeout\_seconds](#input\_visibility\_timeout\_seconds)    | The visibility timeout for the queue. An integer from 0 to 43200                                                                   | `string`       | `"30"`     |    no    |
-| <a name="input_wait_seconds"></a> [wait\_seconds](#input\_wait\_seconds)                                                | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning                         | `string`       | `"10"`     |    no    |
-| <a name="input_write_policy_name"></a> [write\_policy\_name](#input\_write\_policy\_name)                               | The name of the custom write policy                                                                                                | `string`       | `null`     |    no    |
+| Name                                                                                                                 | Description                                                                                                                        | Type           | Default    | Required |
+| -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------- | ---------- | :------: |
+| <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input_content_based_deduplication) | Max receive message count                                                                                                          | `bool`         | `false`    |    no    |
+| <a name="input_delay_seconds"></a> [delay\_seconds](#input_delay_seconds)                                            | The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900                       | `string`       | `"0"`      |    no    |
+| <a name="input_dlq_retention_seconds"></a> [dlq\_retention\_seconds](#input_dlq_retention_seconds)                   | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days)          | `string`       | `"259200"` |    no    |
+| <a name="input_enabled_dead_letter_queue"></a> [enabled\_dead\_letter\_queue](#input_enabled_dead_letter_queue)      | Enable dead letter queue                                                                                                           | `bool`         | `true`     |    no    |
+| <a name="input_enabled_read_write_policy"></a> [enabled\_read\_write\_policy](#input_enabled_read_write_policy)      | Enable read-write policy                                                                                                           | `bool`         | `false`    |    no    |
+| <a name="input_fifo_deduplication_scope"></a> [fifo\_deduplication\_scope](#input_fifo_deduplication_scope)          | Specifies whether message deduplication occurs at the message group or queue level. (perQueue or perMessageGroupId)                | `string`       | `null`     |    no    |
+| <a name="input_fifo_enabled"></a> [fifo\_enabled](#input_fifo_enabled)                                               | Specify whether enable FIFO or not for the SQS queue                                                                               | `bool`         | `false`    |    no    |
+| <a name="input_fifo_throughput_limit"></a> [fifo\_throughput\_limit](#input_fifo_throughput_limit)                   | Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group (perQueue or perMessageGroupId) | `string`       | `null`     |    no    |
+| <a name="input_max_receive_count"></a> [max\_receive\_count](#input_max_receive_count)                               | Max receive message count                                                                                                          | `number`       | `3`        |    no    |
+| <a name="input_max_size"></a> [max\_size](#input_max_size)                                                           | The limit of how many bytes a message can contain before Amazon SQS rejects it                                                     | `string`       | `"2048"`   |    no    |
+| <a name="input_name"></a> [name](#input_name)                                                                        | The name for creating queue names                                                                                                  | `string`       | n/a        |   yes    |
+| <a name="input_principal_roles"></a> [principal\_roles](#input_principal_roles)                                      | A list of IAM roles that a specific principal (user, service, or account) can assume.                                              | `list(string)` | `null`     |    no    |
+| <a name="input_read_policy_name"></a> [read\_policy\_name](#input_read_policy_name)                                  | The name of the custom read policy                                                                                                 | `string`       | `null`     |    no    |
+| <a name="input_read_write_policy_name"></a> [read\_write\_policy\_name](#input_read_write_policy_name)               | Custom name for the read-write policy                                                                                              | `string`       | `null`     |    no    |
+| <a name="input_retention_seconds"></a> [retention\_seconds](#input_retention_seconds)                                | The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days)          | `string`       | `"86400"`  |    no    |
+| <a name="input_visibility_timeout_seconds"></a> [visibility\_timeout\_seconds](#input_visibility_timeout_seconds)    | The visibility timeout for the queue. An integer from 0 to 43200                                                                   | `string`       | `"30"`     |    no    |
+| <a name="input_wait_seconds"></a> [wait\_seconds](#input_wait_seconds)                                               | The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning                         | `string`       | `"10"`     |    no    |
+| <a name="input_write_policy_name"></a> [write\_policy\_name](#input_write_policy_name)                               | The name of the custom write policy                                                                                                | `string`       | `null`     |    no    |
 
 ## Outputs
 
-| Name                                                                                                                                  | Description                                                      |
-|---------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| <a name="output_dlq"></a> [dlq](#output\_dlq)                                                                                         | The SQS dead letter queue info                                   |
-| <a name="output_iam_policy_sqs_read_arn"></a> [iam\_policy\_sqs\_read\_arn](#output\_iam\_policy\_sqs\_read\_arn)                     | n/a                                                              |
-| <a name="output_iam_policy_sqs_read_write_arn"></a> [iam\_policy\_sqs\_read\_write\_arn](#output\_iam\_policy\_sqs\_read\_write\_arn) | The ARN of the IAM policy for read-write access to the SQS queue |
-| <a name="output_iam_policy_sqs_write_arn"></a> [iam\_policy\_sqs\_write\_arn](#output\_iam\_policy\_sqs\_write\_arn)                  | n/a                                                              |
-| <a name="output_queue"></a> [queue](#output\_queue)                                                                                   | The SQS queue info                                               |
+| Name                                                                                                                            | Description                                                      |
+| ------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| <a name="output_dlq"></a> [dlq](#output_dlq)                                                                                    | The SQS dead letter queue info                                   |
+| <a name="output_iam_policy_sqs_read_arn"></a> [iam\_policy\_sqs\_read\_arn](#output_iam_policy_sqs_read_arn)                    | n/a                                                              |
+| <a name="output_iam_policy_sqs_read_write_arn"></a> [iam\_policy\_sqs\_read\_write\_arn](#output_iam_policy_sqs_read_write_arn) | The ARN of the IAM policy for read-write access to the SQS queue |
+| <a name="output_iam_policy_sqs_write_arn"></a> [iam\_policy\_sqs\_write\_arn](#output_iam_policy_sqs_write_arn)                 | n/a                                                              |
+| <a name="output_queue"></a> [queue](#output_queue)                                                                              | The SQS queue info                                               |
 
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,10 @@ locals {
   aws_region      = data.aws_region.current.name
   queue_resources = concat([aws_sqs_queue.queue.arn], (var.enabled_dead_letter_queue == true ? [aws_sqs_queue.dlq[0].arn] : []))
 
+  principal_roles = var.principal_roles != null ? var.principal_roles : [
+    "arn:aws:iam::${local.aws_account_id}:root"
+  ]
+
   redrive_policy = <<POLICY
 {
   "deadLetterTargetArn":"${try(aws_sqs_queue.dlq[0].arn, "")}",
@@ -29,6 +33,9 @@ resource "aws_sqs_queue" "dlq" {
 
   fifo_queue = var.fifo_enabled
 
+  kms_master_key_id                 = var.enabled_kms_encryption ? var.kms_config.kms_master_key_id : null
+  kms_data_key_reuse_period_seconds = var.enabled_kms_encryption ? var.kms_config.kms_data_key_reuse_period_seconds : null
+
   redrive_allow_policy = jsonencode({
     redrivePermission = "byQueue",
     sourceQueueArns   = [aws_sqs_queue.queue.arn]
@@ -51,6 +58,9 @@ resource "aws_sqs_queue" "queue" {
   deduplication_scope         = var.fifo_deduplication_scope
   fifo_throughput_limit       = var.fifo_throughput_limit
   content_based_deduplication = var.content_based_deduplication
+
+  kms_master_key_id                 = var.enabled_kms_encryption ? var.kms_config.kms_master_key_id : null
+  kms_data_key_reuse_period_seconds = var.enabled_kms_encryption ? var.kms_config.kms_data_key_reuse_period_seconds : null
 }
 
 /*
@@ -65,7 +75,7 @@ data "aws_iam_policy_document" "this" {
 
     principals {
       type        = "AWS"
-      identifiers = var.principal_roles != null ? var.principal_roles : ["*"]
+      identifiers = local.principal_roles
     }
 
     actions   = ["sqs:*"]
@@ -83,6 +93,7 @@ resource "aws_sqs_queue_policy" "this" {
   policy    = data.aws_iam_policy_document.this.json
 }
 
+
 resource "aws_sqs_queue_redrive_policy" "this" {
   count = var.enabled_dead_letter_queue ? 1 : 0
 
@@ -91,4 +102,27 @@ resource "aws_sqs_queue_redrive_policy" "this" {
     deadLetterTargetArn = aws_sqs_queue.dlq[0].arn
     maxReceiveCount     = var.max_receive_count
   })
+}
+
+data "aws_iam_policy_document" "sqs_dlq" {
+  count = var.enabled_dead_letter_queue ? 1 : 0
+
+  version = "2012-10-17"
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = local.principal_roles
+    }
+
+    actions   = ["sqs:*"]
+    resources = [aws_sqs_queue.dlq[0].arn]
+  }
+}
+
+resource "aws_sqs_queue_policy" "dlq" {
+  count     = var.enabled_dead_letter_queue && var.enabled_dlq_queue_policy ? 1 : 0
+  queue_url = aws_sqs_queue.dlq[0].url
+  policy    = data.aws_iam_policy_document.sqs_dlq[0].json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,3 +106,27 @@ variable "enabled_dead_letter_queue" {
   type        = bool
   default     = true
 }
+
+variable "enabled_dlq_queue_policy" {
+  description = "Enable dead letter queue policy"
+  type        = bool
+  default     = false
+}
+
+variable "enabled_kms_encryption" {
+  description = "Enable KMS encryption for the SQS queue (by default, AWS SSE-SQS is used)"
+  type        = bool
+  default     = false
+}
+
+variable "kms_config" {
+  description = "KMS configuration for the SQS queue"
+  type = object({
+    kms_master_key_id                 = string
+    kms_data_key_reuse_period_seconds = number
+  })
+  default = {
+    kms_master_key_id                 = "alias/aws/sqs"
+    kms_data_key_reuse_period_seconds = 300
+  }
+}


### PR DESCRIPTION
## Summary

This PR enhances the security posture of the SQS module by implementing more secure defaults and adding custom KMS encryption capabilities.

### Why

The current module defaults allow overly broad IAM access with wildcard (`*`) principals, which poses a security risk. Additionally, the module lacks KMS encryption support for queues that require enhanced security. The dead letter queue (DLQ) also needed its own dedicated policy management.

### What

- **Breaking Change**: Updated the default `principal_roles` to remove wildcard (`*`) access, now defaulting to the AWS account root instead
- Added KMS encryption support for both main queue and DLQ with configurable settings
- Introduced `enabled_dlq_queue_policy` variable to optionally enable separate DLQ queue policies
- Added separate IAM policy document and queue policy resources specifically for DLQ
- Updated module source to Terraform Registry format (`c0x12c/sqs/aws`)
- Documentation updates, including version bump to 0.3.0

### Solution

The implementation follows AWS security best practices by:
- Replacing the wildcard principal with a more secure default (account root) while maintaining flexibility through the `principal_roles` variable
- Adding optional KMS encryption support via the new `enabled_kms_encryption` flag and `kms_config` object, allowing users to choose between AWS managed SSE-SQS (default) or customer-managed KMS keys
- Creating dedicated IAM policy documents and queue policies for the DLQ to enable fine-grained access control
- Maintaining backward compatibility for existing users while providing opt-in security enhancements

## Types of Changes

- [x] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🔒 Security awareness (changes that effect permission scope, security scenarios)
- [x] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan

Testing should verify:
1. **Breaking Change**: Confirm that queues created with default settings now use the account root principal instead of wildcard
2. **KMS Encryption**: Test queue creation with `enabled_kms_encryption = true` and custom `kms_config` values
3. **DLQ Policy**: Verify DLQ policy creation when `enabled_dlq_queue_policy = true`
4. **Backward Compatibility**: Existing deployments with explicit `principal_roles` should continue to work without issues

## Related Issues

<!-- Add any related issue numbers or discussion links -->